### PR TITLE
utils/cluster: For local/multiprocessing cluster, use forkserver method.

### DIFF
--- a/caiman/cluster.py
+++ b/caiman/cluster.py
@@ -406,7 +406,8 @@ def setup_cluster(backend='multiprocessing', n_processes=None, single_thread=Fal
                 raise Exception(
                     'A cluster is already runnning. Terminate with dview.terminate() if you want to restart.')
             c = None
-            dview = Pool(n_processes)
+            ctx = multiprocessing.get_context('forkserver')
+            dview = ctx.Pool(n_processes)
         else:
             raise Exception('Unknown Backend')
 


### PR DESCRIPTION
- numpy multithreaded BLAS/linalg do not work with multiprocessing's standard method, at least on MacOS.
See https://github.com/numpy/numpy/issues/654